### PR TITLE
refactor(cherow): alternative non-ascii WS optimization

### DIFF
--- a/packages/cherow/src/chars.ts
+++ b/packages/cherow/src/chars.ts
@@ -1,5 +1,4 @@
 import { unicodeLookup } from './unicode';
-import { State } from './state';
 
 /*@internal*/
 export const enum CharType {
@@ -306,13 +305,3 @@ export const enum Chars {
     ByteOrderMark      = 0b1111111111101111,
     BigEndian          = 0b1111111111101110
 }
-
-/*@internal*/
-export const whiteSpaceMap: Function[] = new Array(0xFEFF);
-const truthFn = (state: State) => { state.index++; state.column++; return true; };
-const falsyFn = () => false;
-
-whiteSpaceMap.fill(falsyFn);
-whiteSpaceMap.fill(truthFn, 0x9, 0xD + 1);
-whiteSpaceMap.fill(truthFn, 0x2000, 0x200A + 1);
-whiteSpaceMap[0xA0] = whiteSpaceMap[0x1680] = whiteSpaceMap[0x202F] = whiteSpaceMap[0x205F] = whiteSpaceMap[0x3000] = whiteSpaceMap[0xFEFF] = truthFn;

--- a/packages/cherow/src/lexer/common.ts
+++ b/packages/cherow/src/lexer/common.ts
@@ -1,6 +1,6 @@
 import { ParserState } from '../types';
 import { Token } from '../token';
-import { Chars, whiteSpaceMap } from '../chars';
+import { Chars } from '../chars';
 import { mustEscape, isIDStart } from '../unicode';
 import { Context, Flags } from '../common';
 import { report, Errors } from '../errors';

--- a/packages/cherow/src/lexer/identifier.ts
+++ b/packages/cherow/src/lexer/identifier.ts
@@ -1,8 +1,8 @@
 import { Token, descKeywordTable } from '../token';
 import { ParserState } from '../types';
-import { Chars, isIdentifierPart, AsciiLookup, CharType, whiteSpaceMap } from '../chars';
+import { Chars, isIdentifierPart, AsciiLookup, CharType } from '../chars';
 import { Context } from '../common';
-import { nextChar, fromCodePoint, toHex, skipToNewLine } from './common';
+import { nextChar, fromCodePoint, toHex } from './common';
 import { report, Errors } from '../errors';
 
 /**
@@ -120,15 +120,6 @@ export function scanIdentifierUnicodeEscape(state: ParserState): number {
  * @param context Context masks
  */
 export function maybeIdentifier(state: ParserState, context: Context): Token {
-
-  // Both 'PS' and 'LS' have the 5th bit set and 7th bit unset. Checking for that first prevents additional checks
-  if ((state.nextChar & 83) < 3 &&
-      (state.nextChar === Chars.ParagraphSeparator ||
-          state.nextChar === Chars.LineSeparator)) {
-      return skipToNewLine(state);
-  }
-
-  if (whiteSpaceMap[state.nextChar](state)) return Token.WhiteSpace;
 
   if ((state.nextChar & 0xFC00) === 0xD800) {
       state.index++;


### PR DESCRIPTION
I'm not suire if this is faster. Can someone benchmark this?