### PR TITLE
chore(tsconfig): do not preserve const enums

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "noImplicitThis": true,
     "noUnusedParameters": true,
     "outDir": "dist",
-    "preserveConstEnums": true,
+    "preserveConstEnums": false,
     "preserveWatchOutput": true,
     "pretty": true,
     "removeComments": true,


### PR DESCRIPTION
@KFlash As discussed, simply disable const enum preservation.
This brings the minified bundle from 86kb back down to 70kb.
Does this fix https://github.com/cherow/cherow/issues/255 or is there anything else you'd like to address?