### PR TITLE
Nightly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,23 @@
 version: 2.1
 
+map-1: &filter_only_master
+  filters:
+    branches:
+      only:
+        - master
+
+map-2: &filter_only_dev
+  filters:
+    branches:
+      only:
+        - dev
+
+map-3: &filter_ignore_dev
+  filters:
+    branches:
+      ignore:
+        - dev
+
 executors:
 
   docker-circleci:
@@ -45,10 +63,90 @@ jobs:
       - run: npm ci
       - run: npm run test
 
+  publish_dev:
+    executor: docker-circleci
+    steps:
+      - checkout
+      - run: npm ci
+      - run:
+          name: "Authenticate with registry"
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run:
+          name: "Publish to @dev"
+          command: |
+            npm run prepare-nightly
+            npm publish --tag dev
+
+  merge_and_dist:
+    executor: docker-circleci
+    parameters:
+      from:
+        type: string
+        default: "master"
+      to:
+        type: string
+        default: "dev"
+      message:
+        type: string
+        default: "chore(all): add latest build artifacts"
+    steps:
+      - checkout
+      - run: npm ci
+      - run: npm run bundle
+      - run:
+          name: "Stash dist folder"
+          command: |
+            git add dist --force
+            git stash
+      - run:
+          name: "Merge << parameters.from >> into << parameters.to >>"
+          command: |
+            git checkout << parameters.to >>
+            git merge << parameters.from >> --no-ff --no-edit -Xtheirs
+      - run:
+          name: "Overwrite existing with stashed dist folders"
+          command: |
+            rm -rf dist
+            git add .
+            git stash pop
+            git add dist --force
+      - run:
+          name: "Commit dist folders"
+          command: git commit --allow-empty -m "<< parameters.message >>"
+      - run:
+          name: "Push << parameters.to >>"
+          command: git push origin << parameters.to >>
+
 workflows:
   build_test:
+    jobs:
+      - build:
+          <<: *filter_ignore_dev
+      - lint:
+          <<: *filter_ignore_dev
+      - bundle:
+          <<: *filter_ignore_dev
+      - test:
+          <<: *filter_ignore_dev
+
+  publish_nightly:
+    jobs:
+      - publish_dev:
+          <<: *filter_only_dev
+
+  run_nightly:
+    triggers:
+      - schedule:
+          <<: *filter_only_master
+          cron: "0 0 * * *"
     jobs:
       - build
       - lint
       - bundle
       - test
+      - merge_and_dist:
+          requires:
+            - build
+            - lint
+            - bundle
+            - test

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:watch": "npm run test -- --watch --watch-extensions ts",
     "test:verbose": "npm run test -- -R spec",
     "test:watch:verbose": "npm run test:watch -- -R spec",
+    "prepare-nightly": "node scripts/bump-dev-version",
     "coverage": "cross-env TS_NODE_PROJECT=\"test/tsconfig.json\" nyc -n src/**/*.ts -e .ts -i ts-node/register -r text-summary -r lcov -r html npm test",
     "post_coverage": "cross-env cat ./coverage/lcov.info | coveralls"
   },

--- a/scripts/bump-dev-version.js
+++ b/scripts/bump-dev-version.js
@@ -1,0 +1,61 @@
+const { readFile, writeFile } = require('fs');
+const project = require('./project');
+
+async function loadPackageJson(isLockfile) {
+  const file = isLockfile ? 'package-lock.json' : 'package.json';
+  return new Promise((resolve, reject) => {
+    readFile(project[file].path, (err, data) => {
+      if (err) {
+        reject(err);
+      }
+      const str = data.toString('utf8');
+      const json = JSON.parse(str);
+      resolve(json);
+    });
+  });
+}
+
+async function savePackageJson(pkg, isLockfile) {
+  const file = isLockfile ? 'package-lock.json' : 'package.json';
+  return new Promise((resolve, reject) => {
+    const str = JSON.stringify(pkg, null, 2);
+    writeFile(project[file].path, str, { encoding: 'utf8' }, err => {
+      if (err) {
+        reject(err);
+      }
+      resolve();
+    });
+  });
+}
+
+async function run() {
+  versionRegExp = /(\d+)\.(\d+)\.(\d+)($|\-)/;
+  const match = project.pkg.version.match(versionRegExp);
+  if (match === null) {
+    throw new Error(`package.json 'version' should match ${versionRegExp}`);
+  }
+  const major = match[1];
+  const minor = match[2];
+  const patch = match[3];
+  console.log(`current version: ${major}.${minor}.${patch}`);
+
+  const raw = new Date().toISOString().replace(/:|T|\.|-/g, '').slice(0, 8);
+  const y = raw.slice(0, 4);
+  const m = raw.slice(4, 6);
+  const d = raw.slice(6, 8);
+  const datestamp = `${y}${m}${d}`;
+  const newVersion = `${major}.${minor}.${patch}-dev.${datestamp}`;
+  console.log(`new version: ${newVersion}`);
+
+  const packageJson = await loadPackageJson(false);
+  packageJson.version = newVersion;
+  await savePackageJson(packageJson, false);
+
+  const packageLockJson = await loadPackageJson(true);
+  packageLockJson.version = newVersion;
+  await savePackageJson(packageLockJson, true);
+}
+
+run().then(() => {
+  console.log(`Done.`);
+});

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -1,22 +1,19 @@
-const path = require('path');
+const { join } = require('path');
 const rollup = require('rollup');
 const typescript2 = require('rollup-plugin-typescript2');
 const { terser } = require('rollup-plugin-terser');
 const ts = require('typescript');
-
-const root = path.resolve(__dirname, '..');
-const src = path.join(root, 'src');
-const dist = path.join(root, 'dist');
+const project = require('./project');
 
 async function createBundle() {
   for (const type of ['normal', 'minified']) {
     console.log(`creating ${type} bundle`);
 
     const bundle = await rollup.rollup({
-      input: path.join(src, 'cherow.ts'),
+      input: project.entry.path,
       plugins: [
         typescript2({
-          tsconfig: path.join(root, 'tsconfig.json'),
+          tsconfig: project['tsconfig.json'].path,
           typescript: ts
         }),
         ...(type === 'minified' ? [terser()] : [])
@@ -28,7 +25,7 @@ async function createBundle() {
     //'amd' | 'cjs' | 'system' | 'es' | 'esm' | 'iife' | 'umd'
 
     for (const format of ['esm', 'system', 'cjs']) {
-      const fileName = path.join(dist, `cherow.${format}${suffix}.js`);
+      const fileName = join(project.dist.path, `cherow.${format}${suffix}.js`);
 
       console.log(`writing ${fileName}`);
 
@@ -40,7 +37,7 @@ async function createBundle() {
     }
 
     for (const format of ['umd', 'amd', 'iife']) {
-      const fileName = path.join(dist, `cherow.${format}${suffix}.js`);
+      const fileName = join(project.dist.path, `cherow.${format}${suffix}.js`);
 
       console.log(`writing ${fileName}`);
 

--- a/scripts/project.js
+++ b/scripts/project.js
@@ -1,0 +1,19 @@
+const { join, resolve } = require('path');
+const packageJson = require('../package.json');
+
+const root = resolve(__dirname, '..');
+
+module.exports = {
+  'path': root,
+  'pkg': packageJson,
+  'coverage': { 'path': join(root, 'coverage') },
+  'src': { 'path': join(root, 'src') },
+  'entry': { 'path': join(root, 'src', 'cherow.ts') },
+  'dist': { 'path': join(root, 'dist') },
+  'node_modules': { 'path': join(root, 'node_modules') },
+  'scripts': { 'path': join(root, 'scripts') },
+  'test': { 'path': join(root, 'test') },
+  'tsconfig.json': { 'path': join(root, 'tsconfig.json') },
+  'package.json': { 'path': join(root, 'package.json') },
+  'package-lock.json': { 'path': join(root, 'package-lock.json') }
+};


### PR DESCRIPTION
This sets up a nightly build+publish. In summary, here's the workflow:

- Scheduled at 0:00 UTC, CircleCI runs the regular build+lint+test+bundle on the current master branch
- Then it `git add --force` the bundled outputs in the `dist` folder and merges them into the `dev` branch
- The act of pushing to `dev` by CircleCI then triggers the next workflow which bumps the version with a `-dev.yyyymmdd` tag and publishes to npm to `--tag dev`

Notes:
- The major.minor.patch version stays the same, only the nightly tag is added. So today's nightly would have published to `1.6.8-dev.20181219`
- No changelog is generated because there is not sufficient information to be extracted from the commit messages, so normal releases still need to be manually bumped and published.
- This is adapted from the workflow I implemented at Aurelia, but simplified due to being single package. It's therefore also not 100% tested. The first upcoming nightly might fail somehow.
- Any failure will abort the workflow so there is no risk of publishing garbage, just a risk of, well, not publishing at all.

@KFlash sound good to you? any questions/concerns?