### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ Existing parsers have many issues with them:
 
 * `Esprima` is a little faster than Acorn, but it's almost never updated, and their test suite has too many invalid tests. It also doesn't support recent ES standards.
 
-* `Babylon` is highly coupled to Babel, and is comparatively very slow and buggy, and failing to correctly handle even stable ECMAScript standard features.
+* `Babylon` is highly coupled to Babel, and is comparatively very slow.
 
-None of these parsers would fare any chance against the official Test262 suite, and most fail a substantial number of them.
+Most of these parsers would fare any chance against the official Test262 suite, and most fail a substantial number of them.
 
 We figured we could *try* do better. *We* are used in plural form because Cherow is developed by a main developer and two
 others "*behind the scenes*" that contributes with their knowledge whenever it's necessary.


### PR DESCRIPTION
Hi :slightly_smiling_face:

I opened this PR hoping to get the "Babylon is failing to correctly handle even stable ECMAScript standard features" removed.

As of today, Babylon is passing 67960<sup>[1]</sup> out of 69297 test262 tests: that is 98%! (If you think that it is too low, feel free to close this PR)
You can find the full lists of the failing tests at https://github.com/babel/babel/blob/master/scripts/tests/test262/test262_whitelist.txt, in case that you want to check if what I said is true.

Most of the failing tests are:
- Missing early errors for duplicate declarations (e.g. `let a; let a;`)
- Missing early errors for invalid regular expressions
- Missing early errors for AnnexB stuff.

Out of the ~1500 failing tests, about ~150 are not in one of those categories.

<sup>[1]</sup>This number isn't from the `master` branch, but from https://github.com/babel/babel/pull/9365 in which I only updated test262 to the last version.