### PR TITLE
Handle numbers starting with dot

### DIFF
--- a/src/scanner/numeric.ts
+++ b/src/scanner/numeric.ts
@@ -30,11 +30,12 @@ export function returnBigIntOrNumericToken(state: ParserState): Token {
 export function scanNumeric(state: ParserState, context: Context, first: number): Token {
   state.tokenValue = 0;
   let digit = 9;
-  do {
+  while (isDigit(first)) {
     state.tokenValue = 10 * state.tokenValue + (first - Chars.Zero);
     advanceOne(state);
+    first = state.source.charCodeAt(state.index);
     --digit;
-  } while (isDigit((first = state.source.charCodeAt(state.index))));
+  }
 
   if (digit >= 0 && state.index < state.length && first !== Chars.Period && !isIdentifierStart(first)) {
     if (context & Context.OptionsRaw) state.tokenRaw = state.source.slice(state.startIndex, state.index);

--- a/test/parser/literals/numbers.ts
+++ b/test/parser/literals/numbers.ts
@@ -141,5 +141,44 @@ pass('Literal - Numbers (pass)', [
       ],
       sourceType: 'script'
     }
+  ],
+  [
+    '.123',
+    Context.Empty,
+    {
+      type: 'Program',
+      body: [
+        {
+          type: 'ExpressionStatement',
+          expression: {
+            type: 'Literal',
+            value: 0.123
+          }
+        }
+      ],
+      sourceType: 'script'
+    }
+  ],
+  [
+    '-0.5',
+    Context.Empty,
+    {
+      type: 'Program',
+      body: [
+        {
+          type: 'ExpressionStatement',
+          expression: {
+            argument: {
+              type: 'Literal',
+              value: 0.5
+            },
+            operator: '-',
+            prefix: true,
+            type: 'UnaryExpression'
+          }
+        }
+      ],
+      sourceType: 'script'
+    }
   ]
 ]);


### PR DESCRIPTION
ScanNumeric should handle float numbers starting with dot. For example:
```
let a = .5;
```